### PR TITLE
Parse additional options

### DIFF
--- a/dhcp_options.h
+++ b/dhcp_options.h
@@ -385,3 +385,9 @@ const char *client_architecture_names[] = {
 /*   8 */ "EFI Xscale",
 /*   9 */ "EFI BC"
 };
+
+//From rfc 2563
+const char *auto_configure[] = {
+/*   0 */ "DoNotAutoConfigure",
+/*   1 */ "AutoConfigure"
+};

--- a/dhcp_options.h
+++ b/dhcp_options.h
@@ -371,3 +371,17 @@ const char *htypes[] = {
 /*  37 */ "HFI",
 /*  38 */ "Unified Bus"
 };
+
+// From RFC 4578 and errata
+const char *client_architecture_names[] = {
+/*   0 */ "Intel x86PC",
+/*   1 */ "NEC/PC98",
+/*   2 */ "Itanium",
+/*   3 */ "DEC Alpha",
+/*   4 */ "Arc x86",
+/*   5 */ "Intel Lean Client",
+/*   6 */ "EFI IA32",
+/*   7 */ "EFI x86-64",
+/*   8 */ "EFI Xscale",
+/*   9 */ "EFI BC"
+};

--- a/dhcpdump.c
+++ b/dhcpdump.c
@@ -489,6 +489,14 @@ static inline int printdata(uint8_t *data,int data_len) { // {{{ print the heade
 				}
 				break;
 
+			case 93: // Client System Architecture
+                                printf("%d (%s)",data[j+3],data[j+3]>strcountof(client_architecture_names)?"*unknown*":client_architecture_names[data[j+3]]);
+                                break;
+
+			case 94: // Client Network Interface Identifier
+				printf("%u (Rev %d.%d)", (data[j+3]<<8|data[j+4]),data[j+3],data[j+4]);
+				break;
+
 			case 121: // Classless static route
 			case 249: // MSFT - Classless route
                                 printIPaddressCompactMaskAddress(data+j+2,data[j+1]);

--- a/dhcpdump.c
+++ b/dhcpdump.c
@@ -119,6 +119,17 @@ static inline void printIPaddressMask(uint8_t *data) { // {{{ print the data as 
 		data[4],data[5],data[6],data[7]);
 } // }}}
 
+static inline void printIPaddressCompactMaskAddress(uint8_t *data, int len) { // {{{ print the data as series of IP address and masks
+	int i,j;
+	for (i=0;i<len;i++) {
+		j=4+(data[i]+7)/8;
+		printf("%u.%u.%u.%u/%u,%u.%u.%u.%u ",
+			j>4?data[i+1]:0,j>5?data[i+2]:0,j>6?data[i+3]:0,j>7?data[i+4]:0,data[i],
+			data[j-3],data[j-2],data[j-1],data[j]);
+		i=i+j;
+	}
+} // }}}
+
 static inline void print8bits(uint8_t *data) { // {{{ prints a value of 8 bits (1 byte)
 	printf("%u",data[0]);
 } // }}}
@@ -477,6 +488,11 @@ static inline int printdata(uint8_t *data,int data_len) { // {{{ print the heade
 					i+=data[i+1]+2;
 				}
 				break;
+
+			case 121: // Classless static route
+			case 249: // MSFT - Classless route
+                                printIPaddressCompactMaskAddress(data+j+2,data[j+1]);
+                                break;
 
 		}
 		printf("\n");

--- a/dhcpdump.c
+++ b/dhcpdump.c
@@ -497,6 +497,10 @@ static inline int printdata(uint8_t *data,int data_len) { // {{{ print the heade
 				printf("%u (Rev %d.%d)", (data[j+3]<<8|data[j+4]),data[j+3],data[j+4]);
 				break;
 
+			case 116: // Auto-Configure
+				printf("%d (%s)",data[j+2],data[j+2]>strcountof(auto_configure)?"*unknown*":auto_configure[data[j+2]]);
+				break;
+
 			case 121: // Classless static route
 			case 249: // MSFT - Classless route
                                 printIPaddressCompactMaskAddress(data+j+2,data[j+1]);


### PR DESCRIPTION
Parse classless static routes option 121, 249 using compact address & mask format (from rfc3422)

Parse PXE related options 93, 94 (from rfc4578 & errata)

Parse Stateless autoconfigure option 116  (rfc2563)
